### PR TITLE
bugfix: make the generated docker image independant of supplied APPLICATION_ENVIRONMENT when looking for UI files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM armory-docker-local.jfrog.io/armory-cloud/go-app
 MAINTAINER engineering@armory.io
 COPY ./build/dist/linux_amd64/potatofacts /opt/go-application/goapp
-COPY ./ui/dist/staging /opt/go-application/ui/staging
-COPY ./ui/dist/prod /opt/go-application/ui/prod
-
+COPY ./ui/dist/prod /opt/go-application/ui/dist/prod
+#explicitly define default workdirectory, so in case the image is used without any value for APPLICATION_ENVIRONMENT it will still be able to find default location of UI content
+WORKDIR /opt/go-application

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,6 @@ debug: SHELL:=/usr/bin/env bash
 debug: export ADDITIONAL_ACTIVE_PROFILES="local-overrides"
 debug: export APPLICATION_NAME=${APP_NAME}
 debug: export APPLICATION_VERSION=${VERSION}
-run: export SERVER_SPA_DIRECTORY=/ui/dist
 debug: build-dirs
 	@echo "Building ${DIST_DIR}/${APP_NAME}..."
 	@go build -ldflags "-X main.version=${VERSION}" -o ${DIST_DIR}/${APP_NAME}-debug -gcflags "all=-N -l" cmd/${APP_NAME}/main.go
@@ -158,7 +157,6 @@ run: SHELL:=/usr/bin/env bash
 run: export ADDITIONAL_ACTIVE_PROFILES="local-overrides"
 run: export APPLICATION_NAME=${APP_NAME}
 run: export APPLICATION_VERSION=${VERSION}
-run: export SERVER.SPA.DIRECTORY=/home/fieldju/dev/armory-io/potato-facts-go/ui/dist
 run: build-dirs
 	@echo "Building ${DIST_DIR}/${APP_NAME}..."
 	@go build -ldflags "-X main.version=${VERSION}" -o ${DIST_DIR}/${APP_NAME} cmd/${APP_NAME}/main.go

--- a/cmd/potatofacts/resources/potatofacts-prod.yaml
+++ b/cmd/potatofacts/resources/potatofacts-prod.yaml
@@ -1,3 +1,0 @@
-server:
-  spa:
-    directory: /opt/go-application/ui/prod

--- a/cmd/potatofacts/resources/potatofacts-staging.yaml
+++ b/cmd/potatofacts/resources/potatofacts-staging.yaml
@@ -1,3 +1,0 @@
-server:
-  spa:
-    directory: /opt/go-application/ui/staging

--- a/cmd/potatofacts/resources/potatofacts.yaml
+++ b/cmd/potatofacts/resources/potatofacts.yaml
@@ -12,3 +12,4 @@ server:
   spa:
     enabled: true
     prefix: /ui
+    directory: /opt/go-application/ui/dist/prod #default ui files location whenever any environment variable is set (prod, staging, blue-green-prod, etc..) otherwise - check config/config.go how location is calculated

--- a/internal/potatofacts/config/config.go
+++ b/internal/potatofacts/config/config.go
@@ -36,18 +36,24 @@ type Configuration struct {
 	Tracing tracing.Configuration
 }
 
+const uiFilesLocation = "server.spa.directory"
+
 func ConfigurationProvider(
-	logger *zap.SugaredLogger,
-	resources embed.FS,
-	app metadata.ApplicationMetadata,
+  logger *zap.SugaredLogger,
+  resources embed.FS,
+  app metadata.ApplicationMetadata,
 ) (*Configuration, error) {
 	explicitProperties := make(map[string]any)
+	// in case of local run or when docker image is used in k8s manifest without providing APPLICATION_ENVIRONMENT env variable - try using the default location (current workdir + ui/dist/prod sub folder)
 	if app.Environment == "local" {
 		pwd, err := os.Getwd()
 		if err != nil {
 			return nil, err
 		}
-		explicitProperties["server.spa.directory"] = filepath.Join(pwd, "ui", "dist", "prod")
+
+		location := filepath.Join(pwd, "ui", "dist", "prod")
+		logger.Infof("using %s as a value for %s", location, uiFilesLocation)
+		explicitProperties[uiFilesLocation] = location
 	}
 	return c.ResolveConfiguration[Configuration](logger,
 		c.WithBaseConfigurationNames("potatofacts"),


### PR DESCRIPTION
The potato-facts docker image is used in k8s manfiests with various values for APPLICATION_ENVIRONMENT variable, but the UI files location was specified only for prod and staging values. 
This fix defines default ui location (for both local development as well for any values of APPLICATION_ENVIRONMENT)